### PR TITLE
Made https default connection protocol

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,9 +16,9 @@ chrome.runtime.onInstalled.addListener(function(details){
 			console.log("no language selected, defaulting to english");
 		}
 		if(localStorage.getItem("protocol") === null){
-			var protocol = "http://";
+			var protocol = "https://";
 			localStorage["protocol"] = protocol;
-			console.log("no protocol selected, defaulting to http");
+			console.log("no protocol selected, defaulting to https (secure)");
 		}
 	}
 	if(localStorage.getItem("version") != chrome.runtime.getManifest().version){

--- a/options.html
+++ b/options.html
@@ -89,8 +89,8 @@ You should have received a copy of the GNU General Public License along with thi
 						</td>
 						<td>
 							<select id="protocol" name="protocol">
+								<option value="https://">HTTPS (secure)</option>
 								<option value="http://">HTTP</option>
-								<option value="https://">HTTPS</option>
 							</select>
 						</td>
 					</tr>


### PR DESCRIPTION
I personally think the default protocol should be https to protect non-techies from snoopers unless there's a compelling reason otherwise? Also changed the label to `HTTPS (secure)` since non-techies may not realize why one is better than the other and this briefly hints why.